### PR TITLE
Fix for state syntax transformation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    "env",
-    "react",
-    "stage-2"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@css-blocks/jsx": "^0.18.0",
+    "@css-blocks/jsx": "^0.19.0",
     "@css-blocks/runtime": "^0.18.0",
-    "@css-blocks/webpack": "^0.18.0",
+    "@css-blocks/webpack": "^0.19.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",

--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -16,11 +16,11 @@ export default class Button extends Component {
   render() {
     const style = objstr({
       [styles]: true,
-      // [styles.active()]: this.state.isActive
+      [styles.active()]: this.state.isActive
     });
 
     return (
-      <button className={styles} onClick={this.toggleIsActive.bind(this)}>
+      <button className={style} onClick={this.toggleIsActive.bind(this)}>
         {this.state.isActive ? "Active" : "Inactive"}
       </button>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,14 @@ module.exports = {
           {
             loader: require.resolve('babel-loader'),
             options: {
+              presets: ["env", "react", "stage-2"],
+              cacheDirectory: true,
+              compact: true
+            }
+          },
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
               plugins: [
                 require('@css-blocks/jsx/dist/src/transformer/babel').makePlugin(
                   {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,8 @@ module.exports = {
     new CssBlocksPlugin({
       analyzer,
       outputCssFile: 'bundle.css',
-      ...jsxCompilationOptions
+      compilationOptions: jsxCompilationOptions.compilationOptions,
+      optimization: jsxCompilationOptions.optimization
     })
   ],
   resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,10 +54,6 @@ module.exports = {
             }
           }
         ]
-      },
-      {
-        test: /.css$/,
-        loader: require.resolve('file-loader')
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const { Rewriter, Analyzer } = require('@css-blocks/jsx');
 const { CssBlocksPlugin } = require('@css-blocks/webpack');
 
+const cssBlocksRewriter = require('@css-blocks/jsx/dist/src/transformer/babel')
+
 const jsxCompilationOptions = {
   compilationOptions: {},
   optimization: {
@@ -37,11 +39,7 @@ module.exports = {
             loader: require.resolve('babel-loader'),
             options: {
               plugins: [
-                require('@css-blocks/jsx/dist/src/transformer/babel').makePlugin(
-                  {
-                    rewriter
-                  }
-                )
+                cssBlocksRewriter.makePlugin({ rewriter })
               ],
               parserOpts: {
                 plugins: ['jsx']

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@css-blocks/core@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@css-blocks/core/-/core-0.18.0.tgz#ad5181f41441a643c1b814fd4405a38f4dadee76"
+"@css-blocks/core@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@css-blocks/core/-/core-0.19.0.tgz#89cb5584b09ffb2dbbb597570ccc7a6e32eb4839"
   dependencies:
     "@opticss/element-analysis" "^0.3.0"
     "@opticss/template-api" "^0.3.0"
@@ -22,16 +22,16 @@
     source-map "^0.6.1"
     watch "^1.0.2"
 
-"@css-blocks/jsx@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@css-blocks/jsx/-/jsx-0.18.0.tgz#bd100a37992a4b2f1381d7d87db31fe7344baed1"
+"@css-blocks/jsx@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@css-blocks/jsx/-/jsx-0.19.0.tgz#23e4228489bd6b935f8b3cee513209552cae146f"
   dependencies:
-    "@css-blocks/core" "^0.18.0"
+    "@css-blocks/core" "^0.19.0"
     "@opticss/template-api" "^0.3.0"
     "@opticss/util" "^0.3.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.17.4"
+    babel-traverse "7.0.0-beta.3"
+    babel-types "7.0.0-beta.3"
+    babylon "7.0.0-beta.46"
     debug "^2.6.8"
     minimatch "^3.0.4"
     object.values "^1.0.4"
@@ -41,11 +41,11 @@
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/@css-blocks/runtime/-/runtime-0.18.0.tgz#9a6caf07f1074867d46807c4a2843d5418332122"
 
-"@css-blocks/webpack@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@css-blocks/webpack/-/webpack-0.18.0.tgz#6b463ca0c157f68fb6c0aeae4d429277db86a30c"
+"@css-blocks/webpack@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@css-blocks/webpack/-/webpack-0.19.0.tgz#249baf91c5a173303e187d64b0d90b850c857f95"
   dependencies:
-    "@css-blocks/core" "^0.18.0"
+    "@css-blocks/core" "^0.19.0"
     "@opticss/element-analysis" "^0.3.0"
     "@opticss/template-api" "^0.3.0"
     async "^2.4.1"
@@ -214,6 +214,14 @@ atob@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
 
+babel-code-frame@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz#1614a91b2ba0e3848559f410bbacd030726899c9"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -318,6 +326,15 @@ babel-helper-explode-class@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
+babel-helper-function-name@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz#e86dd2eb2c09e06e392e79e203fc02427b24c871"
+  dependencies:
+    babel-helper-get-function-arity "7.0.0-beta.3"
+    babel-template "7.0.0-beta.3"
+    babel-traverse "7.0.0-beta.3"
+    babel-types "7.0.0-beta.3"
+
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
@@ -327,6 +344,12 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-get-function-arity@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz#61a47709318a31bc2db872f4be9b4c8447198be8"
+  dependencies:
+    babel-types "7.0.0-beta.3"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -801,6 +824,16 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+babel-template@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-beta.3.tgz#ebb877b6070ce9912b0d0c22fcad3372165913a8"
+  dependencies:
+    babel-code-frame "7.0.0-beta.3"
+    babel-traverse "7.0.0-beta.3"
+    babel-types "7.0.0-beta.3"
+    babylon "7.0.0-beta.27"
+    lodash "^4.2.0"
+
 babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
@@ -810,6 +843,19 @@ babel-template@^6.24.1, babel-template@^6.26.0:
     babel-types "^6.26.0"
     babylon "^6.18.0"
     lodash "^4.17.4"
+
+babel-traverse@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz#3cf0a45d53d934d85275d8770775d7944fc7c199"
+  dependencies:
+    babel-code-frame "7.0.0-beta.3"
+    babel-helper-function-name "7.0.0-beta.3"
+    babel-types "7.0.0-beta.3"
+    babylon "7.0.0-beta.27"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
 
 babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
@@ -825,6 +871,14 @@ babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
+babel-types@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.3.tgz#cd927ca70e0ae8ab05f4aab83778cfb3e6eb20b4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
@@ -834,7 +888,15 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.17.4, babylon@^6.18.0:
+babylon@7.0.0-beta.27:
+  version "7.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.27.tgz#b6edd30ef30619e2f630eb52585fdda84e6542cd"
+
+babylon@7.0.0-beta.46:
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.46.tgz#b6ddaba81bbb130313932757ff9c195d527088b6"
+
+babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1018,7 +1080,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.2:
+chalk@^2.0.0, chalk@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
   dependencies:
@@ -1238,6 +1300,12 @@ date-now@^0.1.4:
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
@@ -1675,6 +1743,10 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -1832,7 +1904,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -2109,7 +2181,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.14.0, lodash@^4.17.4:
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -3184,6 +3256,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 to-object-path@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This was a bit tricky. The issue was that babel was running before css-blocks, so the AST we saw didn't match the syntax that we expected. I had to remove the .babelrc file and instead moved the babel presets into an explicit loader that runs after our loader. I think we need to find a way to integrate with webpack that is more friendly to the `.babelrc` approach -- but I'm not sure what would be.

Ping: @amiller-gh

I did some other small tweaks, but this is the commit that really mattered:
https://github.com/matthiaskern/css-blocks-hello-world/commit/027b0d7c94d6bef6398cd20efab11f18c505abb6